### PR TITLE
Add unit tests for document API methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ test = [
   "pytest>=8.4.1",
   "pytest-cov>=6.2.1",
   "pytest-emoji>=0.2.0",
+  "pytest-httpx>=0.30.0",
   "pytest-md>=0.2.0",
 ]
 doc = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def mock_client(base_url):
 
 
 @pytest.fixture
-def mock_authenticated_client(base_url, api_token):
+def templafy_client(base_url, api_token):
     """Mock authenticated client for testing."""
     return AuthenticatedClient(base_url=base_url, token=api_token)
 
@@ -90,3 +90,24 @@ def mock_library_data():
             "is_active": True,
         },
     ]
+
+
+@pytest.fixture
+def sample_document():
+    """Sample document data for testing."""
+    return {
+        "id": "doc1",
+        "name": "Test Document 1",
+        "description": "A test document",
+        "template_type": "word",
+        "library_id": "lib1",
+        "folderId": "folder1",
+        "tags": ["test", "document"],
+        "fileSize": 1024,
+        "checksum": "abc123",
+        "fileExtension": "docx",
+        "downloadUrl": "https://example.com/download/doc1.docx",
+        "navigationPath": "/folder1/doc1.docx",
+        "modifiedAt": "2023-01-01T00:00:00Z",
+        "assetState": "ready",
+    }

--- a/tests/templafy/api/conftest.py
+++ b/tests/templafy/api/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture
+def sample_library_data():
+    """Sample library data for testing get_libraries."""
+    return [
+        {
+            "id": 1,
+            "name": "Test Library",
+            "libraryType": "documents",
+            "spaceId": 1,
+            "rootFolderId": 1,
+        }
+    ]
+
+
+@pytest.fixture
+def sample_library_details_data():
+    """Sample library details data for testing get_libraries_space_id_library_type."""
+    return {
+        "id": 1,
+        "name": "Test Library Details",
+        "libraryType": "documents",
+        "spaceId": 1,
+        "rootFolderId": 1,
+    }

--- a/tests/templafy/api/documents/test_create.py
+++ b/tests/templafy/api/documents/test_create.py
@@ -1,0 +1,27 @@
+from io import BytesIO
+
+from httpx import codes
+
+from templafy.api.documents import (
+    post_libraries_space_id_documents_folders_folder_id_assets as api,
+)
+from templafy.models.post_libraries_space_id_documents_folders_folder_id_assets_body import (
+    PostLibrariesSpaceIdDocumentsFoldersFolderIdAssetsBody,
+)
+from templafy.types import File
+
+
+def test_create_document_returns_document(httpx_mock, templafy_client):
+    # Create mock file
+    mock_file = File(
+        payload=BytesIO(b"mock file content"),
+        file_name="test.docx",
+        mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    body = PostLibrariesSpaceIdDocumentsFoldersFolderIdAssetsBody(file=mock_file)
+
+    httpx_mock.add_response(status_code=codes.CREATED, json=123)
+
+    result = api.sync(space_id=1, folder_id=1, client=templafy_client, body=body)
+
+    assert result == 123

--- a/tests/templafy/api/documents/test_delete_by_id.py
+++ b/tests/templafy/api/documents/test_delete_by_id.py
@@ -1,0 +1,13 @@
+from httpx import codes
+
+from templafy.api.documents import (
+    delete_libraries_space_id_documents_assets_asset_id as api,
+)
+
+
+def test_delete_document_by_id_returns_none_on_204(httpx_mock, templafy_client):
+    httpx_mock.add_response(status_code=codes.NO_CONTENT)
+
+    result = api.sync(space_id=1, asset_id=123, client=templafy_client)
+
+    assert result is None

--- a/tests/templafy/api/documents/test_generate.py
+++ b/tests/templafy/api/documents/test_generate.py
@@ -1,0 +1,23 @@
+from httpx import codes
+
+from templafy.api.documents import (
+    post_libraries_space_id_documents_assets_asset_id_generate as api,
+)
+from templafy.models.generate_file_request import GenerateFileRequest
+
+
+def test_generate_document_returns_expected_payload(httpx_mock, templafy_client):
+    body = GenerateFileRequest(email="test@example.com")
+    payload = {
+        "downloadUrl": "https://example.com/generated.docx",
+        "fileSize": 1024,
+        "checksum": "abc123",
+        "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "fileExtension": "docx",
+    }
+    httpx_mock.add_response(status_code=codes.OK, json=payload)
+
+    result = api.sync(space_id=1, asset_id=123, client=templafy_client, body=body)
+
+    assert result is not None
+    assert result.download_url == payload["downloadUrl"]

--- a/tests/templafy/api/documents/test_get_by_id.py
+++ b/tests/templafy/api/documents/test_get_by_id.py
@@ -1,0 +1,17 @@
+from httpx import codes
+
+from templafy.api.documents import (
+    get_libraries_space_id_documents_assets_asset_id as api,
+)
+
+
+def test_get_document_by_id_returns_parsed_list(
+    httpx_mock, templafy_client, sample_document
+):
+    # stub httpx response
+    httpx_mock.add_response(status_code=codes.OK, json=[sample_document])
+
+    result = api.sync(space_id=1, asset_id=123, client=templafy_client)
+
+    assert isinstance(result, list)
+    assert result[0].id == sample_document["id"]

--- a/tests/templafy/api/documents/test_list_in_folder.py
+++ b/tests/templafy/api/documents/test_list_in_folder.py
@@ -1,0 +1,16 @@
+from httpx import codes
+
+from templafy.api.documents import (
+    get_libraries_space_id_documents_folders_folder_id_assets as api,
+)
+
+
+def test_list_documents_in_folder_returns_document_list(
+    httpx_mock, templafy_client, sample_document
+):
+    httpx_mock.add_response(status_code=codes.OK, json=[sample_document])
+
+    result = api.sync(space_id=1, folder_id=1, client=templafy_client)
+
+    assert isinstance(result, list)
+    assert result[0].id == sample_document["id"]

--- a/tests/templafy/api/documents/test_update.py
+++ b/tests/templafy/api/documents/test_update.py
@@ -1,0 +1,17 @@
+from httpx import codes
+
+from templafy.api.documents import (
+    patch_libraries_space_id_documents_assets_asset_id as api,
+)
+from templafy.models.patch_libraries_space_id_documents_assets_asset_id_body import (
+    PatchLibrariesSpaceIdDocumentsAssetsAssetIdBody,
+)
+
+
+def test_update_document_returns_none_on_204(httpx_mock, templafy_client):
+    httpx_mock.add_response(status_code=codes.NO_CONTENT)
+
+    body = PatchLibrariesSpaceIdDocumentsAssetsAssetIdBody()
+    result = api.sync(space_id=1, asset_id=123, client=templafy_client, body=body)
+
+    assert result is None

--- a/tests/templafy/api/libraries/test_libraries_get_by_space_and_type.py
+++ b/tests/templafy/api/libraries/test_libraries_get_by_space_and_type.py
@@ -1,0 +1,18 @@
+from httpx import codes
+
+from templafy.api.libraries import get_libraries_space_id_library_type
+from templafy.models.library_type import LibraryType
+
+
+def test_get_library_by_space_and_type_returns_details(
+    httpx_mock, templafy_client, sample_library_details_data
+):
+    # Mock httpx response
+    httpx_mock.add_response(status_code=codes.OK, json=sample_library_details_data)
+
+    result = get_libraries_space_id_library_type.sync(
+        space_id=1, library_type=LibraryType.DOCUMENTS, client=templafy_client
+    )
+
+    assert result is not None
+    assert result.root_folder_id == sample_library_details_data["rootFolderId"]

--- a/tests/templafy/api/libraries/test_libraries_get_libraries.py
+++ b/tests/templafy/api/libraries/test_libraries_get_libraries.py
@@ -1,0 +1,12 @@
+from httpx import codes
+
+from templafy.api.libraries import get_libraries
+
+
+def test_get_libraries_returns_list(httpx_mock, templafy_client, sample_library_data):
+    # Mock httpx response
+    httpx_mock.add_response(status_code=codes.OK, json=sample_library_data)
+
+    result = get_libraries.sync(client=templafy_client)
+
+    assert isinstance(result, list)

--- a/tests/templafy/test_client.py
+++ b/tests/templafy/test_client.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    assert True

--- a/uv.lock
+++ b/uv.lock
@@ -908,7 +908,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -2157,6 +2157,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
+]
+
+[[package]]
 name = "pytest-md"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2698,6 +2711,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-emoji" },
+    { name = "pytest-httpx" },
     { name = "pytest-md" },
 ]
 
@@ -2734,6 +2748,7 @@ test = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-emoji", specifier = ">=0.2.0" },
+    { name = "pytest-httpx", specifier = ">=0.30.0" },
     { name = "pytest-md", specifier = ">=0.2.0" },
 ]
 


### PR DESCRIPTION
This pull request introduces a comprehensive suite of tests for the document-related API endpoints in the `templafy` package. It also adds new test fixtures and updates dependencies to support HTTPX-based testing. The most important changes are grouped below by theme.

**Testing for Document API Endpoints:**

* Added tests for creating documents, ensuring the API returns the expected document payload. (`tests/templafy/api/documents/test_create.py`)
* Added tests for deleting documents by ID, verifying the API returns `None` on successful deletion (HTTP 204). (`tests/templafy/api/documents/test_delete_by_id.py`)
* Added tests for generating documents, checking that the API returns the correct payload and download URL. (`tests/templafy/api/documents/test_generate.py`)
* Added tests for retrieving documents by ID and listing documents in a folder, confirming correct parsing and payload structure. (`tests/templafy/api/documents/test_get_by_id.py`, `tests/templafy/api/documents/test_list_in_folder.py`) [[1]](diffhunk://#diff-e66c2f2fb898d44aaf43fdbb625f9f45f9d5ad7301b8e60735a70e4c66e19a36R1-R17) [[2]](diffhunk://#diff-25a304b6b169ba8a559cdbde4ddb3da5e7709843fa8a50e5e2056ff8de62f197R1-R16)
* Added tests for updating documents, ensuring the API returns `None` on successful update (HTTP 204). (`tests/templafy/api/documents/test_update.py`)

**Test Infrastructure and Fixtures:**

* Added the `pytest-httpx` dependency to `pyproject.toml` to enable HTTPX mocking in tests.
* Renamed the authenticated client fixture for clarity and added a new fixture for sample document data. (`tests/conftest.py`) [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L36-R36) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R93-R113)